### PR TITLE
add ability to create new dispatch class hierarchies

### DIFF
--- a/lib/CLI/Dispatch.pm
+++ b/lib/CLI/Dispatch.pm
@@ -122,7 +122,7 @@ sub _find_help {
         $class = shift @namespaces;
         next unless $class->isa( 'CLI::Dispatch' );
         $class .= "::Help";
-        last if use_module( $class );
+        last if $class = eval { use_module( $class ) };
     }
 
     return $class;

--- a/lib/CLI/Dispatch/Command.pm
+++ b/lib/CLI/Dispatch/Command.pm
@@ -81,7 +81,7 @@ sub usage {
   while ( @namespaces ) {
       my $test = shift @namespaces;
       next unless $test->isa( 'CLI::Dispatch' );
-      last if $help_class == use_module( $test . '::Help' );
+      last if $help_class = eval { use_module( $test . '::Help' ) };
   }
   my $help = $help_class->new(%$self);
 

--- a/lib/CLI/Dispatch/Help.pm
+++ b/lib/CLI/Dispatch/Help.pm
@@ -219,8 +219,14 @@ sub _lookup {
   # probably it's embedded in the caller...
   my $ct = 0;
   my %seen;
+
+  # we're guaranteed to get 'CLI::Dispatch' in this list.
+  my $ignore = join(  '|', $self->dispatch_class,
+                      do { no strict 'refs'; @{ *{"@{[ $self->dispatch_class ]}::ISA"}{ARRAY} } },
+                   );
+
   while (my @caller = caller($ct++)) {
-    next if $caller[0] =~ /^(@{[$self->_dispatch_class]}|CLI::Dispatch)(::.+)?$/;
+    next if $caller[0] =~ /^($ignore)(::.+)?$/;
     next if $seen{$caller[0]}++;
     my $content = path($caller[1])->slurp;
     for my $path ( @paths ) {

--- a/subclass-example/lib/Inherit/Dispatch.pm
+++ b/subclass-example/lib/Inherit/Dispatch.pm
@@ -1,0 +1,16 @@
+package Inherit::Dispatch;
+
+use base 'CLI::Dispatch';
+
+sub options {
+    my $self = shift;
+    [ $self->SUPER::options ];
+}
+
+sub get_options {
+    my ( $self, $specs ) = @_;
+    $self->SUPER::get_options( @$specs );
+}
+
+
+1;

--- a/subclass-example/lib/Inherit/Dispatch/Command.pm
+++ b/subclass-example/lib/Inherit/Dispatch/Command.pm
@@ -1,0 +1,19 @@
+package Inherit::Dispatch::Command;
+
+use base 'CLI::Dispatch::Command';
+
+sub dispatch_class { 'Inherit::Dispatch' }
+
+sub options {
+    my $self = shift;
+    [ $self->SUPER::options ];
+}
+
+sub check {
+
+    shift;
+    print ">> @{[__PACKAGE__]} <<\n";
+    return 1;
+}
+
+1;

--- a/subclass-example/lib/Inherit/Dispatch/Help.pm
+++ b/subclass-example/lib/Inherit/Dispatch/Help.pm
@@ -1,0 +1,20 @@
+package Inherit::Dispatch::Help;
+
+use base 'CLI::Dispatch::Help';
+
+sub dispatch_class { 'Inherit::Dispatch' }
+
+sub options {
+    my $self = shift;
+    [ $self->SUPER::options ];
+}
+
+sub output {
+
+    my $self = shift;
+
+    print ">> @{[__PACKAGE__]} <<\n";
+    $self->SUPER::output( @_ );
+}
+
+1;

--- a/subclass-example/lib/MyScript.pm
+++ b/subclass-example/lib/MyScript.pm
@@ -1,0 +1,6 @@
+package MyScript;
+
+use strict;
+use base 'Inherit::Dispatch';
+
+1;

--- a/subclass-example/lib/MyScript/Boo.pm
+++ b/subclass-example/lib/MyScript/Boo.pm
@@ -1,0 +1,22 @@
+package MyScript::Boo;
+use Data::Dumper;
+
+use parent 'Inherit::Dispatch::Command';
+
+sub run {
+    my ( $self, @args ) = @_;
+
+    print Dumper $self;
+    print Dumper \@args;
+
+}
+
+1;
+
+
+=head1 NAME
+
+MyScript::Boo
+
+=cut
+

--- a/subclass-example/tst.pl
+++ b/subclass-example/tst.pl
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use lib '../lib';
+use lib './lib';
+
+use MyScript;
+
+MyScript->run;
+
+
+


### PR DESCRIPTION
I'd like to create a new dispatch class hierarchy based upon `CLI::Dispatch`.  The motivation is that I'd like to use another options parser (e.g. `Getopt::Long::Descriptive` rather than `Getopt::Long`).

`CLI::Dispatch::Command` and `CLI::Dispatch::Help` are typically extended in order to create commands, not to create a parallel dispatch class hierarchy. They (and `CLI::Dispatch`) make assumptions about how to recognize the actual dispatch module and the class hierarchy (for example, class names such as `CLI::Dispatch` and `CLI::Dispatch::Help` are hardwired into the code).

As the code in both `CLI::Dispatch::Command` and `CLI::Dispatch::Help` can be called either as a command or from within a dispatch class, it's impossible to figure out which context code is called in and thus automatically deduce what the actual dispatch class is.  In order to disambiguate that, I introduced a new class method, `dispatch_class`, which returns the root dispatch class (it defaults to `CLI::Dispatch`) and which can be overridden by subclasses.  Since `Help` commands can exist anywhere in the inheritance hierarchy of the dispatch class, when  `Help` is not provided by the application, the inheritance hierarchy is searched for the first class whose namespace contains `Help`.

I've temporarily added some example code in `subclass-example`, which simply modifies `Dispatch`'s `get_options` method to accept an arrayref rather than an array.

Is this approach something you'd consider?

Thanks,
Diab